### PR TITLE
Add Google Maps embed to Visítanos section

### DIFF
--- a/index.html
+++ b/index.html
@@ -430,16 +430,19 @@
         }
 
         .map-placeholder {
+            position: relative;
             border-radius: 20px;
-            border: 1px dashed rgba(10, 35, 66, 0.4);
-            background: rgba(255, 255, 255, 0.85);
-            padding: 2rem;
-            display: flex;
-            align-items: center;
-            justify-content: center;
-            text-align: center;
+            overflow: hidden;
             min-height: 260px;
-            color: rgba(10, 35, 66, 0.7);
+            box-shadow: 0 12px 30px rgba(10, 35, 66, 0.12);
+        }
+
+        .map-placeholder iframe {
+            width: 100%;
+            height: 100%;
+            min-height: 260px;
+            border: 0;
+            display: block;
         }
 
         .contact-actions {
@@ -731,8 +734,7 @@
                         </ul>
                     </div>
                     <div class="map-placeholder">
-                        <!-- Insertar iframe de Google Maps con la URL del embed aquí -->
-                        <p>Espacio reservado para el mapa. Agregá tu <em>iframe</em> de Google Maps cuando tengas la URL.</p>
+                        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3271.4269668038087!2d-57.94778332338645!3d-34.920827374316005!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x95a2e7a51e86ace7%3A0xf219b22e0317f3ab!2sAscend!5e0!3m2!1ses!2sar!4v1759677987778!5m2!1ses!2sar" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- embed the provided Google Maps iframe in the Visítanos section
- update the map container styling to display the iframe responsively

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68e28eb012048323aaab7eef48669c3c